### PR TITLE
Поддержка двойных кавычек в именах полей для тестов

### DIFF
--- a/ansible-playbook/vars/metrics-catalog.testing.yml
+++ b/ansible-playbook/vars/metrics-catalog.testing.yml
@@ -31,7 +31,7 @@ metrics_catalog:
           ##
           ## Метрики Интернет магазина
           ##
-          - selector:  "Запросы к главной странице интернет магазина"
+          - selector: "Запросы к главной странице интернет магазина"
             filter:
               http_path: # имя поля в событии лога (входящие данные трансформа vector.dev)
                 # возможные условия отбора: eq -> ==, neq -> !=, re -> match_any(), nre -> !match_any.
@@ -114,8 +114,8 @@ metrics_catalog:
           namespace: "namespace"
           method: "http_method"
           status: "http_status_code"
-        event_selectors: &kubedns_http_requests_total_event_selectors
-          # фильтры подходящих нам метирик
+        event_selectors:
+          &kubedns_http_requests_total_event_selectors # фильтры подходящих нам метирик
           - selector: Монолит - входящие запросы по kubedns
             filter:
               namespace:

--- a/files/aggregator/tests/logs-to-metrics_tests.testing.toml.j2
+++ b/files/aggregator/tests/logs-to-metrics_tests.testing.toml.j2
@@ -227,7 +227,7 @@
           {%- set selector_index = (loop.index | string) -%}
 
         {%- for test_conf in selector_conf.testdata -%}
-          {%- set test_name = "transforms.metrics-http-accesslog-k8s: check metric " + metric_full_name + "(sel:" + selector_index + ", test:" + (loop.index | string) + ")" -%}
+          {%- set test_name = "transforms.metrics-http-accesslog-k8s: check metric " + metric_full_name + "(selector #" + selector_index + ", test #" + (loop.index | string) + ")" -%}
 
 [[tests]]
   name = "{{ test_name }}"
@@ -239,7 +239,7 @@
     [tests.inputs.log_fields]
       # сгенерированные строки
       {% for logfield_name, logfield_value in test_conf.input_values.items() -%}
-      "{{ logfield_name }}" = "{{ logfield_value }}"
+      "{{ logfield_name | replace('"','\\"') | safe }}" = "{{ logfield_value | replace('"','\\"') | safe }}"
       {# newline #}
       {%- endfor %}
 


### PR DESCRIPTION
Имя с точкой, например, `.Resource."http.response.status_code"`, где `http.response.status_code` нужно брать в кавычки `"`, иначе это в тесте vector считается за обращение к вложенному полю, что неверно в этом контексте. 

В тесте должно быть `"Resource.\"http.response.status_code\""`. 

Это важно при использовании имен из [OpenTelemetry Attributes Registry](https://opentelemetry.io/docs/specs/semconv/attributes-registry/). 